### PR TITLE
Changed navigation for servers to have sublevels [#66]

### DIFF
--- a/androidVariant/src/androidTest/java/org/comixedproject/variant/android/ui/links/ServerLinkItemViewKtTest.kt
+++ b/androidVariant/src/androidTest/java/org/comixedproject/variant/android/ui/links/ServerLinkItemViewKtTest.kt
@@ -39,7 +39,7 @@ class ServerLinkItemViewKtTest {
         SERVER_LINK_LIST.filter { entry -> entry.linkType == ServerLinkType.PUBLICATION }.first()
 
     @Test
-    fun navigationLink_showsNavigationIcon() {
+    fun serverLinkItemView_navigationLink_showsNavigationIcon() {
         composeTestRule.setContent {
             ServerLinkListItemView(navigationServerLink, onLoadLink = {}, onShowInfo = {})
         }
@@ -49,7 +49,7 @@ class ServerLinkItemViewKtTest {
     }
 
     @Test
-    fun navigationLink_showsTitle() {
+    fun serverLinkItemView_navigationLink_showsTitle() {
         composeTestRule.setContent {
             ServerLinkListItemView(navigationServerLink, onLoadLink = {}, onShowInfo = {})
         }
@@ -62,7 +62,7 @@ class ServerLinkItemViewKtTest {
     }
 
     @Test
-    fun navigationLink_icon_onClick_callsLoadLink() {
+    fun serverLinkItemView_navigationLink_icon_onClick_callsLoadLink() {
         var clicked = false
         composeTestRule.setContent {
             ServerLinkListItemView(
@@ -76,7 +76,7 @@ class ServerLinkItemViewKtTest {
     }
 
     @Test
-    fun navigationLink_onClick_callsLoadLink() {
+    fun serverLinkItemView_navigationLink_onClick_callsLoadLink() {
         var clicked = false
         composeTestRule.setContent {
             ServerLinkListItemView(
@@ -90,7 +90,7 @@ class ServerLinkItemViewKtTest {
     }
 
     @Test
-    fun publicationLink_showsPublicationIcon() {
+    fun serverLinkItemView_publicationLink_showsPublicationIcon() {
         composeTestRule.setContent {
             ServerLinkListItemView(publicationServerLink, onLoadLink = {}, onShowInfo = {})
         }
@@ -100,7 +100,7 @@ class ServerLinkItemViewKtTest {
     }
 
     @Test
-    fun publicationLink_showsTitle() {
+    fun serverLinkItemView_publicationLink_showsTitle() {
         composeTestRule.setContent {
             ServerLinkListItemView(publicationServerLink, onLoadLink = {}, onShowInfo = {})
         }
@@ -113,7 +113,7 @@ class ServerLinkItemViewKtTest {
     }
 
     @Test
-    fun publicationLink_icon_onClick_callsShowInfo() {
+    fun serverLinkItemView_publicationLink_icon_onClick_callsShowInfo() {
         var clicked = false
         composeTestRule.setContent {
             ServerLinkListItemView(
@@ -127,7 +127,7 @@ class ServerLinkItemViewKtTest {
     }
 
     @Test
-    fun publicationLink_onClick_callsLoadLink() {
+    fun serverLinkItemView_publicationLink_onClick_callsLoadLink() {
         var clicked = false
         composeTestRule.setContent {
             ServerLinkListItemView(

--- a/androidVariant/src/androidTest/java/org/comixedproject/variant/android/ui/servers/ServerListViewKtTest.kt
+++ b/androidVariant/src/androidTest/java/org/comixedproject/variant/android/ui/servers/ServerListViewKtTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Variant - A digital comic book reading application for the iPad and Android tablets.
+ * Copyright (C) 2025, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.variant.android.ui.servers
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import junit.framework.TestCase.assertTrue
+import org.comixedproject.variant.android.model.SERVER_LIST
+import org.junit.Rule
+import org.junit.Test
+
+class ServerListViewKtTest {
+    @get:Rule(order = 0)
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun serverListView_addButton_clicked() {
+        var clicked = false
+        composeTestRule.setContent {
+            ServerListView(
+                SERVER_LIST,
+                onAddServer = { clicked = true },
+                onEditServer = { },
+                onDeleteServer = { },
+                onBrowseServer = { _ -> })
+        }
+
+        composeTestRule.onNodeWithTag(TAG_ADD_BUTTON).performClick()
+        assertTrue(clicked)
+    }
+}

--- a/androidVariant/src/main/java/org/comixedproject/variant/android/ui/RootNavigationTargets.kt
+++ b/androidVariant/src/main/java/org/comixedproject/variant/android/ui/RootNavigationTargets.kt
@@ -20,8 +20,14 @@ package org.comixedproject.variant.android.model
 
 import org.comixedproject.variant.android.ui.Screen
 
-enum class NavigationTarget(val screen: Screen) {
+enum class RootNavigationTargets(val screen: Screen) {
     SERVERS(Screen.ServersScreen),
     COMICS(Screen.ComicsScreen),
     SETTINGS(Screen.SettingsScreen)
+}
+
+enum class ServerNavigationTargets(val screen: Screen) {
+    ADD(Screen.AddServerScreen),
+    EDIT(Screen.EditServerScreen),
+    DELETE(Screen.DeleteServerScreen)
 }

--- a/androidVariant/src/main/java/org/comixedproject/variant/android/ui/Screen.kt
+++ b/androidVariant/src/main/java/org/comixedproject/variant/android/ui/Screen.kt
@@ -31,10 +31,12 @@ sealed class Screen(val route: String) {
     object ComicsScreen : Screen("comics_screen")
     object SettingsScreen : Screen("settings_screen")
 
+    object ListServersScreen : Screen("list_servers_screen")
     object AddServerScreen : Screen("add_server_screen")
     object EditServerScreen : Screen("edit_server_screen")
     object DeleteServerScreen : Screen("delete_server_screen")
-    object BrowseServerScreen : Screen("browse_server_screen")
+
+    object BrowseServerLinksScreen : Screen("browse_server_links_screen")
 
     fun withArgs(vararg args: String): String {
         return buildString {

--- a/androidVariant/src/main/java/org/comixedproject/variant/android/ui/servers/ServerListView.kt
+++ b/androidVariant/src/main/java/org/comixedproject/variant/android/ui/servers/ServerListView.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import org.comixedproject.variant.android.R
@@ -41,6 +42,8 @@ import org.comixedproject.variant.android.model.SERVER_LIST
 import org.comixedproject.variant.shared.model.server.Server
 
 private val TAG = "ServersView"
+
+val TAG_ADD_BUTTON = "button.add-server"
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3AdaptiveApi::class)
 @Composable
@@ -61,7 +64,10 @@ fun ServerListView(
             })
         },
         floatingActionButton = {
-            FloatingActionButton(onClick = onAddServer) {
+            FloatingActionButton(
+                onClick = onAddServer,
+                modifier = Modifier.testTag(TAG_ADD_BUTTON)
+            ) {
                 Icon(
                     Icons.Default.Add,
                     contentDescription = stringResource(R.string.serverAddButton)

--- a/androidVariant/src/main/java/org/comixedproject/variant/android/ui/servers/ServersView.kt
+++ b/androidVariant/src/main/java/org/comixedproject/variant/android/ui/servers/ServersView.kt
@@ -1,0 +1,154 @@
+/*
+ * Variant - A digital comic book reading application for the iPad and Android tablets.
+ * Copyright (C) 2025, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.variant.android.ui.servers
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import org.comixedproject.variant.android.VariantTheme
+import org.comixedproject.variant.android.ui.Screen
+import org.comixedproject.variant.shared.model.server.Server
+import org.comixedproject.variant.shared.platform.Logger
+import org.comixedproject.variant.shared.viewmodel.ServerLinkViewModel
+import org.comixedproject.variant.shared.viewmodel.ServerViewModel
+import org.koin.androidx.compose.koinViewModel
+
+private val TAG = "ServersView"
+
+@Composable
+fun ServersView(
+    onBrowseServerLinks: (Server) -> Unit,
+    serverViewModel: ServerViewModel = koinViewModel(),
+    serverLinkViewModel: ServerLinkViewModel = koinViewModel()
+) {
+    val navController = rememberNavController()
+
+    val coroutineScope = rememberCoroutineScope()
+    var currentServerId by rememberSaveable { mutableStateOf<Long?>(null) }
+    var currentDirectory by rememberSaveable { mutableStateOf("") }
+    val serverList by serverViewModel.serverList.collectAsState()
+    var isLoading by rememberSaveable { mutableStateOf(false) }
+
+    NavHost(navController = navController, startDestination = Screen.ListServersScreen.route) {
+        composable(Screen.ListServersScreen.route) {
+
+            ServerListView(
+                serverList,
+                onAddServer = {
+                    Logger.d(TAG, "Add a new server")
+                    navController.navigate(Screen.AddServerScreen.route)
+                },
+                onEditServer = { server ->
+                    Logger.d(TAG, "Editing server: name=${server.name}")
+                    navController.navigate(Screen.EditServerScreen.withArgs("${server.serverId}"))
+                },
+                onDeleteServer = { server ->
+                    Logger.d(TAG, "Deleting server: name=${server.name}")
+                    navController.navigate(Screen.DeleteServerScreen.withArgs("${server.serverId}"))
+                },
+                onBrowseServer = { server ->
+                    Logger.d(TAG, "Starting to browse server: name=${server.name}")
+                    onBrowseServerLinks(server)
+                })
+
+            composable(route = Screen.AddServerScreen.route) {
+                ServerEditView(
+                    Server(null, "", "", "", ""),
+                    onSave = { server ->
+                        Logger.d(
+                            TAG,
+                            "Saving new server: name=${server.name} url=${server.url}"
+                        )
+                        serverViewModel.saveServer(server)
+                        navController.navigate(Screen.ServersScreen.route)
+                    },
+                    onCancel = {
+                        Logger.d(
+                            TAG,
+                            "Cancelling new server"
+                        )
+                        navController.navigate(Screen.ServersScreen.route)
+                    })
+            }
+
+            composable(
+                route = "${Screen.EditServerScreen.route}/{serverId}",
+                arguments = listOf(
+                    navArgument("serverId") {
+                        type = NavType.StringType
+                        nullable = false
+                    }
+                )) { entry ->
+                val serverId = entry.arguments?.getString("serverId")
+                val server = serverList.filter { it.serverId == serverId!!.toLong() }.first()
+
+                ServerEditView(
+                    server,
+                    onSave = { server ->
+                        Logger.d(
+                            TAG,
+                            "Saving server changes: id=${server.serverId} name=${server.name} url=${server.url}"
+                        )
+                        serverViewModel.saveServer(server)
+                        navController.navigate(Screen.ServersScreen.route)
+                    },
+                    onCancel = {
+                        Logger.d(
+                            TAG,
+                            "Canceling changes to server"
+                        )
+                        navController.navigate(Screen.ServersScreen.route)
+                    })
+            }
+
+            composable(
+                route = "${Screen.DeleteServerScreen.route}/{serverId}",
+                arguments = listOf(
+                    navArgument("serverId") {
+                        type = NavType.StringType
+                        nullable = false
+                    }
+                )) { entry ->
+                val serverId = entry.arguments?.getString("serverId")
+                val server = serverList.filter { it.serverId == serverId!!.toLong() }.first()
+
+                Text("Delete Server Screen!")
+            }
+        }
+    }
+}
+
+@Composable
+@Preview
+fun ServersPreview() {
+    VariantTheme {
+        ServersView(onBrowseServerLinks = { _ -> })
+    }
+}


### PR DESCRIPTION
Moved the composable routes for server screens (list, add, edited, and delete) to a separate navigation host from the root navigation host.

Also added a test class for ServerListView.

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

